### PR TITLE
Update map based on new positions from dropped out teams

### DIFF
--- a/maps.svg
+++ b/maps.svg
@@ -14,21 +14,21 @@
    viewBox="0 0 210 148"
    height="148mm"
    width="210mm"
-   inkscape:version="0.92.4 (5da689c313, 2019-01-14)"
+   inkscape:version="0.92.4 5da689c313, 2019-01-14"
    sodipodi:docname="maps.svg">
   <sodipodi:namedview
      inkscape:lockguides="true"
-     inkscape:window-maximized="1"
-     inkscape:window-y="-9"
-     inkscape:window-x="-9"
-     inkscape:window-height="1001"
-     inkscape:window-width="1920"
+     inkscape:window-maximized="0"
+     inkscape:window-y="43"
+     inkscape:window-x="960"
+     inkscape:window-height="1015"
+     inkscape:window-width="956"
      showgrid="true"
-     inkscape:current-layer="g19338"
+     inkscape:current-layer="g19334"
      inkscape:document-units="mm"
-     inkscape:cy="244.02102"
-     inkscape:cx="589.95382"
-     inkscape:zoom="11.313709"
+     inkscape:cy="283.42688"
+     inkscape:cx="260.65887"
+     inkscape:zoom="2.8284273"
      inkscape:pageshadow="2"
      inkscape:pageopacity="0.0"
      borderopacity="1.0"
@@ -38,7 +38,7 @@
      inkscape:snap-text-baseline="true"
      inkscape:measure-start="490,590"
      inkscape:measure-end="220,590"
-     inkscape:snap-bbox="true"
+     inkscape:snap-bbox="false"
      inkscape:snap-nodes="false"
      inkscape:bbox-nodes="true"
      showguides="false">
@@ -7187,8 +7187,7 @@
        style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:condensed;font-size:4.23333311px;line-height:125%;font-family:'Open Sans Condensed';-inkscape-font-specification:'Open Sans Condensed, Bold Condensed';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
        x="25"
        y="103"
-       id="text5567"
-       sodipodi:linespacing="125%"><tspan
+       id="text5567"><tspan
          sodipodi:role="line"
          id="tspan5565"
          x="25"
@@ -7199,8 +7198,7 @@
        style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:condensed;font-size:4.23333311px;line-height:125%;font-family:'Open Sans Condensed';-inkscape-font-specification:'Open Sans Condensed, Bold Condensed';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
        x="25"
        y="110"
-       id="text5567-6"
-       sodipodi:linespacing="125%"><tspan
+       id="text5567-6"><tspan
          sodipodi:role="line"
          id="tspan5565-1"
          x="25"
@@ -7211,8 +7209,7 @@
        style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:condensed;font-size:4.23333311px;line-height:125%;font-family:'Open Sans Condensed';-inkscape-font-specification:'Open Sans Condensed, Bold Condensed';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
        x="25"
        y="124"
-       id="text5567-6-2"
-       sodipodi:linespacing="125%"><tspan
+       id="text5567-6-2"><tspan
          sodipodi:role="line"
          id="tspan5565-1-5"
          x="25"
@@ -7223,8 +7220,7 @@
        style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:condensed;font-size:4.23333311px;line-height:125%;font-family:'Open Sans Condensed';-inkscape-font-specification:'Open Sans Condensed, Bold Condensed';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
        x="24.847601"
        y="137.96614"
-       id="text5567-6-2-8"
-       sodipodi:linespacing="125%"><tspan
+       id="text5567-6-2-8"><tspan
          sodipodi:role="line"
          id="tspan5565-1-5-9"
          x="24.847601"
@@ -7235,8 +7231,7 @@
        style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:condensed;font-size:4.23333311px;line-height:125%;font-family:'Open Sans Condensed';-inkscape-font-specification:'Open Sans Condensed, Bold Condensed';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
        x="24.8349"
        y="143.9619"
-       id="text5567-6-2-8-5"
-       sodipodi:linespacing="125%"><tspan
+       id="text5567-6-2-8-5"><tspan
          sodipodi:role="line"
          id="tspan5565-1-5-9-1"
          x="24.8349"
@@ -7247,8 +7242,7 @@
        style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:condensed;font-size:4.23333311px;line-height:125%;font-family:'Open Sans Condensed';-inkscape-font-specification:'Open Sans Condensed, Bold Condensed';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
        x="24.936501"
        y="116.96613"
-       id="text5567-6-7"
-       sodipodi:linespacing="125%"><tspan
+       id="text5567-6-7"><tspan
          sodipodi:role="line"
          id="tspan5565-1-0"
          x="24.936501"
@@ -7534,8 +7528,7 @@
        style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:11.28888893px;line-height:125%;font-family:Oswald;-inkscape-font-specification:Oswald;text-align:start;letter-spacing:0px;word-spacing:0px;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
        x="10"
        y="18"
-       id="text5571"
-       sodipodi:linespacing="125%"><tspan
+       id="text5571"><tspan
          sodipodi:role="line"
          id="tspan5569"
          x="10"
@@ -7546,8 +7539,7 @@
        style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.11666656px;line-height:125%;font-family:Oswald;-inkscape-font-specification:Oswald;text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
        x="84.201866"
        y="16.144007"
-       id="text2375"
-       sodipodi:linespacing="125%"><tspan
+       id="text2375"><tspan
          sodipodi:role="line"
          id="tspan2373"
          x="84.201866"
@@ -7558,8 +7550,7 @@
        style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.11666656px;line-height:125%;font-family:Oswald;-inkscape-font-specification:Oswald;text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
        x="30"
        y="68"
-       id="text2375-1"
-       sodipodi:linespacing="125%"><tspan
+       id="text2375-1"><tspan
          sodipodi:role="line"
          id="tspan2373-1"
          x="30"
@@ -7570,8 +7561,7 @@
        style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.11666656px;line-height:125%;font-family:Oswald;-inkscape-font-specification:Oswald;text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
        x="75"
        y="113"
-       id="text2375-6"
-       sodipodi:linespacing="125%"><tspan
+       id="text2375-6"><tspan
          sodipodi:role="line"
          id="tspan2373-5"
          x="75"
@@ -7743,8 +7733,7 @@
          style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:condensed;font-size:4.23333311px;line-height:125%;font-family:'Open Sans Condensed';-inkscape-font-specification:'Open Sans Condensed, Bold Condensed';text-align:center;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:middle;fill:#de6400;fill-opacity:1;stroke:none;stroke-width:0.1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
          x="141"
          y="99"
-         id="text5686"
-         sodipodi:linespacing="125%"><tspan
+         id="text5686"><tspan
            sodipodi:role="line"
            id="tspan5684"
            x="141"
@@ -7755,8 +7744,7 @@
          style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:condensed;font-size:4.23333311px;line-height:125%;font-family:'Open Sans Condensed';-inkscape-font-specification:'Open Sans Condensed, Bold Condensed';text-align:center;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:middle;display:inline;fill:#de6400;fill-opacity:1;stroke:none;stroke-width:0.1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
          x="115"
          y="88.000008"
-         id="text5686-8"
-         sodipodi:linespacing="125%"><tspan
+         id="text5686-8"><tspan
            sodipodi:role="line"
            x="115"
            y="88.000008"
@@ -7772,8 +7760,7 @@
          style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:condensed;font-size:4.23333311px;line-height:125%;font-family:'Open Sans Condensed';-inkscape-font-specification:'Open Sans Condensed, Bold Condensed';text-align:center;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:middle;fill:#de6400;fill-opacity:1;stroke:none;stroke-width:0.1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
          x="160.96489"
          y="121.02205"
-         id="text5708"
-         sodipodi:linespacing="125%"><tspan
+         id="text5708"><tspan
            sodipodi:role="line"
            id="tspan5706"
            x="160.96489"
@@ -7789,8 +7776,7 @@
          style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:condensed;font-size:4.23333311px;line-height:125%;font-family:'Open Sans Condensed';-inkscape-font-specification:'Open Sans Condensed, Bold Condensed';text-align:center;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:middle;fill:#de6400;fill-opacity:1;stroke:none;stroke-width:0.1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
          x="95"
          y="121.87112"
-         id="text5714"
-         sodipodi:linespacing="125%"><tspan
+         id="text5714"><tspan
            sodipodi:role="line"
            id="tspan5712"
            x="95"
@@ -8004,11 +7990,6 @@
          sodipodi:nodetypes="ccc" />
       <path
          inkscape:connector-curvature="0"
-         id="rect14804-5-5"
-         d="m 113.91468,61.87228 c 0,0 4.484,-2.68796 4.484,-2.68796 0,0 4.48401,2.68795 4.48401,2.68795 0,0 -4.48401,2.68796 -4.48401,2.68796 0,0 -4.484,-2.68795 -4.484,-2.68795"
-         style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:#ffff00;stroke-width:0.26499999;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.87309648" />
-      <path
-         inkscape:connector-curvature="0"
          id="rect14804-95-0"
          d="m 108.4965,65.12022 c 0,0 4.48401,-2.68795 4.48401,-2.68795 0,0 4.484,2.68795 4.484,2.68795 0,0 -4.484,2.68795 -4.484,2.68795 0,0 -4.48401,-2.68795 -4.48401,-2.68795"
          style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:#ffff00;stroke-width:0.26499999;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.87309648" />
@@ -8016,11 +7997,6 @@
          inkscape:connector-curvature="0"
          id="rect14804-2-9"
          d="m 103.26518,68.25616 c 0,0 4.484,-2.68795 4.484,-2.68795 0,0 4.484,2.68795 4.484,2.68795 0,0 -4.484,2.68795 -4.484,2.68795 0,0 -4.484,-2.68795 -4.484,-2.68795"
-         style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:#ffff00;stroke-width:0.26499999;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.87309648" />
-      <path
-         inkscape:connector-curvature="0"
-         id="rect14804-28-7"
-         d="m 97.847001,71.5041 c 0,0 4.484009,-2.68795 4.484009,-2.68795 0,0 4.484,2.68795 4.484,2.68795 0,0 -4.484,2.68796 -4.484,2.68796 0,0 -4.484009,-2.68796 -4.484009,-2.68796"
          style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:#ffff00;stroke-width:0.26499999;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.87309648" />
       <path
          inkscape:connector-curvature="0"
@@ -8080,12 +8056,12 @@
       <path
          inkscape:connector-curvature="0"
          id="rect14804-71-2"
-         d="m 63.282804,74.75205 c 0,0 4.484004,-2.68795 4.484004,-2.68795 0,0 4.484005,2.68795 4.484005,2.68795 0,0 -4.484005,2.68796 -4.484005,2.68796 0,0 -4.484004,-2.68796 -4.484004,-2.68796"
+         d="m 62.604608,74.424645 c 0,0 4.484004,-2.68795 4.484004,-2.68795 0,0 4.484005,2.68795 4.484005,2.68795 0,0 -4.484005,2.68796 -4.484005,2.68796 0,0 -4.484004,-2.68796 -4.484004,-2.68796"
          style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:#ffff00;stroke-width:0.26499999;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.87309648" />
       <path
          inkscape:connector-curvature="0"
          id="rect14804-32-9"
-         d="m 67.766801,77.44 c 0,0 4.484005,-2.68795 4.484005,-2.68795 0,0 4.484001,2.68795 4.484001,2.68795 0,0 -4.484004,2.68795 -4.484004,2.68795 0,0 -4.484002,-2.68795 -4.484002,-2.68795"
+         d="m 44.867083,71.070718 c 0,0 4.484005,-2.68795 4.484005,-2.68795 0,0 4.484001,2.68795 4.484001,2.68795 0,0 -4.484004,2.68795 -4.484004,2.68795 0,0 -4.484002,-2.68795 -4.484002,-2.68795"
          style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:#ffff00;stroke-width:0.26499999;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.87309648" />
       <g
          id="g3439">
@@ -8181,8 +8157,7 @@
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.11666656px;line-height:125%;font-family:Oswald;-inkscape-font-specification:Oswald;text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
          x="120"
          y="13"
-         id="text5642"
-         sodipodi:linespacing="125%"><tspan
+         id="text5642"><tspan
            sodipodi:role="line"
            id="tspan5640"
            x="120"
@@ -8380,8 +8355,7 @@
          style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:condensed;font-size:4.23333311px;line-height:125%;font-family:'Open Sans Condensed';-inkscape-font-specification:'Open Sans Condensed, Bold Condensed';text-align:center;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:middle;fill:#de6400;fill-opacity:1;stroke:none;stroke-width:0.1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
          x="125"
          y="14.000008"
-         id="text5646"
-         sodipodi:linespacing="125%"><tspan
+         id="text5646"><tspan
            sodipodi:role="line"
            id="tspan5644"
            x="125"
@@ -8392,8 +8366,7 @@
          style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:condensed;font-size:4.23333359px;line-height:100%;font-family:'Open Sans Condensed';-inkscape-font-specification:'Open Sans Condensed, Bold Condensed';text-align:center;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:middle;fill:#de6400;fill-opacity:1;stroke:none;stroke-width:0.1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
          x="82.308937"
          y="24.022045"
-         id="text5646-1"
-         sodipodi:linespacing="100%"><tspan
+         id="text5646-1"><tspan
            sodipodi:role="line"
            id="tspan5644-5"
            x="82.308937"
@@ -8409,8 +8382,7 @@
          style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:condensed;font-size:4.23333311px;line-height:125%;font-family:'Open Sans Condensed';-inkscape-font-specification:'Open Sans Condensed, Bold Condensed';text-align:center;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:middle;fill:#de6400;fill-opacity:1;stroke:none;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
          x="115"
          y="5.0000072"
-         id="text5646-4"
-         sodipodi:linespacing="125%"><tspan
+         id="text5646-4"><tspan
            sodipodi:role="line"
            id="tspan5644-9"
            x="115"
@@ -8445,8 +8417,7 @@
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.11666656px;line-height:125%;font-family:Oswald;-inkscape-font-specification:Oswald;text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
          x="-60"
          y="73"
-         id="text5926"
-         sodipodi:linespacing="125%"><tspan
+         id="text5926"><tspan
            sodipodi:role="line"
            id="tspan5924"
            x="-60"
@@ -8457,8 +8428,7 @@
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.11666656px;line-height:125%;font-family:Oswald;-inkscape-font-specification:Oswald;text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
          x="104"
          y="8"
-         id="text6054"
-         sodipodi:linespacing="125%"><tspan
+         id="text6054"><tspan
            sodipodi:role="line"
            id="tspan6052"
            x="104"
@@ -8475,8 +8445,7 @@
          style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:3.52777767px;line-height:125%;font-family:'Roboto Mono';-inkscape-font-specification:'Roboto Mono, Bold';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
          x="156"
          y="13"
-         id="text6712"
-         sodipodi:linespacing="125%"><tspan
+         id="text6712"><tspan
            sodipodi:role="line"
            x="156"
            y="13"
@@ -8542,8 +8511,7 @@
          style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:condensed;font-size:4.23333311px;line-height:125%;font-family:'Open Sans Condensed';-inkscape-font-specification:'Open Sans Condensed, Bold Condensed';text-align:center;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
          x="180"
          y="8"
-         id="text6833"
-         sodipodi:linespacing="125%"><tspan
+         id="text6833"><tspan
            sodipodi:role="line"
            id="tspan6831"
            x="180"
@@ -9212,8 +9180,7 @@
          style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:3.52777767px;line-height:125%;font-family:'Roboto Mono';-inkscape-font-specification:'Roboto Mono, Bold';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
          x="173"
          y="13"
-         id="text6712-2"
-         sodipodi:linespacing="125%"><tspan
+         id="text6712-2"><tspan
            sodipodi:role="line"
            id="tspan6710-2"
            x="173"
@@ -9279,8 +9246,7 @@
          style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:3.52777767px;line-height:125%;font-family:'Roboto Mono';-inkscape-font-specification:'Roboto Mono, Bold';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
          x="190"
          y="13"
-         id="text6712-9"
-         sodipodi:linespacing="125%"><tspan
+         id="text6712-9"><tspan
            sodipodi:role="line"
            id="tspan6710-3"
            x="190"
@@ -9351,8 +9317,7 @@
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.17499995px;line-height:125%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans, Normal';text-align:center;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:middle;display:inline;fill:#de6400;fill-opacity:1;stroke:none;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
          x="114.55994"
          y="28.076244"
-         id="text7318"
-         sodipodi:linespacing="125%"><tspan
+         id="text7318"><tspan
            sodipodi:role="line"
            id="tspan7316"
            x="114.55994"
@@ -9363,8 +9328,7 @@
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.17499995px;line-height:125%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans, Normal';text-align:center;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:middle;display:inline;fill:#de6400;fill-opacity:1;stroke:none;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
          x="119.08192"
          y="25.388294"
-         id="text7318-8"
-         sodipodi:linespacing="125%"><tspan
+         id="text7318-8"><tspan
            sodipodi:role="line"
            id="tspan7316-2"
            x="119.08192"
@@ -9375,8 +9339,7 @@
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.17499995px;line-height:125%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans, Normal';text-align:center;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:middle;display:inline;fill:#de6400;fill-opacity:1;stroke:none;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
          x="123.47173"
          y="22.76022"
-         id="text7318-5"
-         sodipodi:linespacing="125%"><tspan
+         id="text7318-5"><tspan
            sodipodi:role="line"
            id="tspan7316-3"
            x="123.47173"
@@ -9385,34 +9348,20 @@
       <text
          xml:space="preserve"
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.17499995px;line-height:125%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans, Normal';text-align:center;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:middle;display:inline;fill:#de6400;fill-opacity:1;stroke:none;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         x="127.78403"
-         y="20.124393"
-         id="text7318-87"
-         sodipodi:linespacing="125%"><tspan
+         x="131"
+         y="21"
+         id="text7318-87"><tspan
            sodipodi:role="line"
            id="tspan7316-0"
-           x="127.78403"
-           y="20.124393"
+           x="131"
+           y="21"
            style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.17499995px;font-family:'Open Sans';-inkscape-font-specification:'Open Sans, Normal';text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#de6400;fill-opacity:1;stroke-width:0.26458332px">HRS</tspan></text>
-      <text
-         xml:space="preserve"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.17499995px;line-height:125%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans, Normal';text-align:center;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:middle;display:inline;fill:#de6400;fill-opacity:1;stroke:none;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         x="132.17461"
-         y="22.756344"
-         id="text7318-6"
-         sodipodi:linespacing="125%"><tspan
-           sodipodi:role="line"
-           id="tspan7316-6"
-           x="132.17461"
-           y="22.756344"
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.17499995px;font-family:'Open Sans';-inkscape-font-specification:'Open Sans, Normal';text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#de6400;fill-opacity:1;stroke-width:0.26458332px">RTS</tspan></text>
       <text
          xml:space="preserve"
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.17499995px;line-height:125%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans, Normal';text-align:center;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:middle;display:inline;fill:#de6400;fill-opacity:1;stroke:none;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
          x="127.78403"
          y="25.388304"
-         id="text7318-56"
-         sodipodi:linespacing="125%"><tspan
+         id="text7318-56"><tspan
            sodipodi:role="line"
            id="tspan7316-8"
            x="127.78403"
@@ -9423,8 +9372,7 @@
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.17499995px;line-height:125%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans, Normal';text-align:center;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:middle;display:inline;fill:#de6400;fill-opacity:1;stroke:none;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
          x="123.36477"
          y="28.020248"
-         id="text7318-3"
-         sodipodi:linespacing="125%"><tspan
+         id="text7318-3"><tspan
            sodipodi:role="line"
            id="tspan7316-06"
            x="123.36477"
@@ -9435,8 +9383,7 @@
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.17499995px;line-height:125%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans, Normal';text-align:center;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:middle;display:inline;fill:#de6400;fill-opacity:1;stroke:none;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
          x="118.98929"
          y="30.71208"
-         id="text7318-7"
-         sodipodi:linespacing="125%"><tspan
+         id="text7318-7"><tspan
            sodipodi:role="line"
            id="tspan7316-83"
            x="118.98929"
@@ -9445,22 +9392,20 @@
       <text
          xml:space="preserve"
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.17499995px;line-height:125%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans, Normal';text-align:center;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:middle;display:inline;fill:#de6400;fill-opacity:1;stroke:none;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         x="118.28934"
-         y="63.006313"
-         id="text7318-1"
-         sodipodi:linespacing="125%"><tspan
+         x="49.380371"
+         y="72.165276"
+         id="text7318-1"><tspan
            sodipodi:role="line"
            id="tspan7316-7"
-           x="118.28934"
-           y="63.006313"
+           x="49.380371"
+           y="72.165276"
            style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.17499995px;font-family:'Open Sans';-inkscape-font-specification:'Open Sans, Normal';text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#de6400;fill-opacity:1;stroke-width:0.26458332px">ELC</tspan></text>
       <text
          xml:space="preserve"
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.17499995px;line-height:125%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans, Normal';text-align:center;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:middle;display:inline;fill:#de6400;fill-opacity:1;stroke:none;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
          x="112.93008"
          y="66.001564"
-         id="text7318-76"
-         sodipodi:linespacing="125%"><tspan
+         id="text7318-76"><tspan
            sodipodi:role="line"
            id="tspan7316-9"
            x="112.93008"
@@ -9471,8 +9416,7 @@
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.17499995px;line-height:125%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans, Normal';text-align:center;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:middle;display:inline;fill:#de6400;fill-opacity:1;stroke:none;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
          x="107.8034"
          y="69.390198"
-         id="text7318-61"
-         sodipodi:linespacing="125%"><tspan
+         id="text7318-61"><tspan
            sodipodi:role="line"
            id="tspan7316-24"
            x="107.8034"
@@ -9481,34 +9425,31 @@
       <text
          xml:space="preserve"
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.17499995px;line-height:125%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans, Normal';text-align:center;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:middle;display:inline;fill:#de6400;fill-opacity:1;stroke:none;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         x="102.28058"
-         y="72.638145"
-         id="text7318-16"
-         sodipodi:linespacing="125%"><tspan
+         x="68.397659"
+         y="83.719299"
+         id="text7318-16"><tspan
            sodipodi:role="line"
            id="tspan7316-87"
-           x="102.28058"
-           y="72.638145"
+           x="68.397659"
+           y="83.719299"
            style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.17499995px;font-family:'Open Sans';-inkscape-font-specification:'Open Sans, Normal';text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#de6400;fill-opacity:1;stroke-width:0.26458332px">GDC</tspan></text>
       <text
          xml:space="preserve"
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.17499995px;line-height:125%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans, Normal';text-align:center;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:middle;display:inline;fill:#de6400;fill-opacity:1;stroke:none;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
          x="83.815804"
          y="80.142738"
-         id="text7318-9"
-         sodipodi:linespacing="125%"><tspan
+         id="text7318-9"><tspan
            sodipodi:role="line"
            id="tspan7316-5"
            x="83.815804"
            y="80.142738"
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.17499995px;font-family:'Open Sans';-inkscape-font-specification:'Open Sans, Normal';text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#de6400;fill-opacity:1;stroke-width:0.26458332px">CTS</tspan></text>
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.17499995px;font-family:'Open Sans';-inkscape-font-specification:'Open Sans, Normal';text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#de6400;fill-opacity:1;stroke-width:0.26458332px">CGS</tspan></text>
       <text
          xml:space="preserve"
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.17499995px;line-height:125%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans, Normal';text-align:center;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:middle;display:inline;fill:#de6400;fill-opacity:1;stroke:none;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
          x="79.253548"
          y="82.829971"
-         id="text7318-11"
-         sodipodi:linespacing="125%"><tspan
+         id="text7318-11"><tspan
            sodipodi:role="line"
            id="tspan7316-34"
            x="79.253548"
@@ -9519,8 +9460,7 @@
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.17499995px;line-height:125%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans, Normal';text-align:center;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:middle;display:inline;fill:#de6400;fill-opacity:1;stroke:none;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
          x="73.101257"
          y="86.525887"
-         id="text7318-877"
-         sodipodi:linespacing="125%"><tspan
+         id="text7318-877"><tspan
            sodipodi:role="line"
            id="tspan7316-65"
            x="73.101257"
@@ -9529,22 +9469,9 @@
       <text
          xml:space="preserve"
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.17499995px;line-height:125%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans, Normal';text-align:center;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:middle;display:inline;fill:#de6400;fill-opacity:1;stroke:none;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         x="68.625"
-         y="83.837929"
-         id="text7318-0"
-         sodipodi:linespacing="125%"><tspan
-           sodipodi:role="line"
-           id="tspan7316-04"
-           x="68.625"
-           y="83.837929"
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.17499995px;font-family:'Open Sans';-inkscape-font-specification:'Open Sans, Normal';text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#de6400;fill-opacity:1;stroke-width:0.26458332px">CHW</tspan></text>
-      <text
-         xml:space="preserve"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.17499995px;line-height:125%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans, Normal';text-align:center;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:middle;display:inline;fill:#de6400;fill-opacity:1;stroke:none;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
          x="64.14875"
          y="81.153847"
-         id="text7318-769"
-         sodipodi:linespacing="125%"><tspan
+         id="text7318-769"><tspan
            sodipodi:role="line"
            id="tspan7316-344"
            x="64.14875"
@@ -9555,8 +9482,7 @@
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.17499995px;line-height:125%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans, Normal';text-align:center;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:middle;display:inline;fill:#de6400;fill-opacity:1;stroke:none;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
          x="59.652336"
          y="78.462021"
-         id="text7318-4"
-         sodipodi:linespacing="125%"><tspan
+         id="text7318-4"><tspan
            sodipodi:role="line"
            id="tspan7316-59"
            x="59.652336"
@@ -9567,8 +9493,7 @@
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.17499995px;line-height:125%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans, Normal';text-align:center;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:middle;display:inline;fill:#de6400;fill-opacity:1;stroke:none;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
          x="55.179958"
          y="75.774063"
-         id="text7318-2"
-         sodipodi:linespacing="125%"><tspan
+         id="text7318-2"><tspan
            sodipodi:role="line"
            id="tspan7316-02"
            x="55.179958"
@@ -9579,8 +9504,7 @@
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.17499995px;line-height:125%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans, Normal';text-align:center;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:middle;display:inline;fill:#de6400;fill-opacity:1;stroke:none;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
          x="61.533043"
          y="72.189377"
-         id="text7318-79"
-         sodipodi:linespacing="125%"><tspan
+         id="text7318-79"><tspan
            sodipodi:role="line"
            id="tspan7316-07"
            x="61.533043"
@@ -9589,34 +9513,20 @@
       <text
          xml:space="preserve"
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.17499995px;line-height:125%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans, Normal';text-align:center;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:middle;display:inline;fill:#de6400;fill-opacity:1;stroke:none;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         x="67.759789"
-         y="75.886093"
-         id="text7318-12"
-         sodipodi:linespacing="125%"><tspan
-           sodipodi:role="line"
-           id="tspan7316-90"
-           x="67.759789"
-           y="75.886093"
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.17499995px;font-family:'Open Sans';-inkscape-font-specification:'Open Sans, Normal';text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#de6400;fill-opacity:1;stroke-width:0.26458332px">SCS</tspan></text>
-      <text
-         xml:space="preserve"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.17499995px;line-height:125%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans, Normal';text-align:center;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:middle;display:inline;fill:#de6400;fill-opacity:1;stroke:none;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         x="72.093407"
-         y="78.573265"
-         id="text7318-33"
-         sodipodi:linespacing="125%"><tspan
+         x="67.070175"
+         y="75.505775"
+         id="text7318-33"><tspan
            sodipodi:role="line"
            id="tspan7316-20"
-           x="72.093407"
-           y="78.573265"
+           x="67.070175"
+           y="75.505775"
            style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.17499995px;font-family:'Open Sans';-inkscape-font-specification:'Open Sans, Normal';text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#de6400;fill-opacity:1;stroke-width:0.26458332px">BRK</tspan></text>
       <text
          xml:space="preserve"
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.17499995px;line-height:125%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans, Normal';text-align:center;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:middle;display:inline;fill:#de6400;fill-opacity:1;stroke:none;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
          x="55.986954"
          y="61.438335"
-         id="text7318-55"
-         sodipodi:linespacing="125%"><tspan
+         id="text7318-55"><tspan
            sodipodi:role="line"
            id="tspan7316-349"
            x="55.986954"
@@ -9627,8 +9537,7 @@
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.17499995px;line-height:125%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans, Normal';text-align:center;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:middle;display:inline;fill:#de6400;fill-opacity:1;stroke:none;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
          x="49.903606"
          y="65.134277"
-         id="text7318-112"
-         sodipodi:linespacing="125%"><tspan
+         id="text7318-112"><tspan
            sodipodi:role="line"
            id="tspan7316-53"
            x="49.903606"
@@ -9639,8 +9548,7 @@
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.17499995px;line-height:125%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans, Normal';text-align:center;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:middle;display:inline;fill:#de6400;fill-opacity:1;stroke:none;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
          x="43.555977"
          y="68.830193"
-         id="text7318-80"
-         sodipodi:linespacing="125%"><tspan
+         id="text7318-80"><tspan
            sodipodi:role="line"
            id="tspan7316-51"
            x="43.555977"
@@ -9651,8 +9559,7 @@
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.17499995px;line-height:125%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans, Normal';text-align:center;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:middle;display:inline;fill:#de6400;fill-opacity:1;stroke:none;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
          x="95.875175"
          y="110.04395"
-         id="text7318-334"
-         sodipodi:linespacing="125%"><tspan
+         id="text7318-334"><tspan
            sodipodi:role="line"
            id="tspan7316-4"
            x="95.875175"
@@ -9663,8 +9570,7 @@
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.17499995px;line-height:125%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans, Normal';text-align:center;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:middle;display:inline;fill:#de6400;fill-opacity:1;stroke:none;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
          x="100.26228"
          y="112.72958"
-         id="text7318-45"
-         sodipodi:linespacing="125%"><tspan
+         id="text7318-45"><tspan
            sodipodi:role="line"
            id="tspan7316-875"
            x="100.26228"
@@ -9675,8 +9581,7 @@
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.17499995px;line-height:125%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans, Normal';text-align:center;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:middle;display:inline;fill:#de6400;fill-opacity:1;stroke:none;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
          x="105.21526"
          y="105.19492"
-         id="text7318-99"
-         sodipodi:linespacing="125%"><tspan
+         id="text7318-99"><tspan
            sodipodi:role="line"
            id="tspan7316-30"
            x="105.21526"
@@ -9687,8 +9592,7 @@
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.17499995px;line-height:125%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans, Normal';text-align:center;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:middle;display:inline;fill:#de6400;fill-opacity:1;stroke:none;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
          x="109.67912"
          y="107.88363"
-         id="text7318-121"
-         sodipodi:linespacing="125%"><tspan
+         id="text7318-121"><tspan
            sodipodi:role="line"
            id="tspan7316-76"
            x="109.67912"
@@ -9699,8 +9603,7 @@
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.17499995px;line-height:125%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans, Normal';text-align:center;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:middle;display:inline;fill:#de6400;fill-opacity:1;stroke:none;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
          x="114.31659"
          y="110.57159"
-         id="text7318-26"
-         sodipodi:linespacing="125%"><tspan
+         id="text7318-26"><tspan
            sodipodi:role="line"
            id="tspan7316-58"
            x="114.31659"


### PR DESCRIPTION
Update maps to reflect new layout of team pits.

- Give HRS 2 desks
- Have only 2 pits in the first part of L3 cafe
- Add an additional pit in main Cafe area
- Remove pit in centre of cafe

(This is how they're laid out currently)